### PR TITLE
Update mocha to a secure version and add unit test timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "8.11.2"

--- a/README.md
+++ b/README.md
@@ -1,16 +1,8 @@
 # express-metrics
 
-[![Build Status](https://travis-ci.org/dgaubert/express-metrics.svg?branch=master)](https://travis-ci.org/dgaubert/express-metrics)
+[![Build Status](https://travis-ci.org/andrew-js-wright/express-metrics.svg?branch=master)](https://travis-ci.org/andrew-js-wright/express-metrics)
 
 Express middleware for collecting and reporting metrics about response times.
-
-## Installation
-
-On project path:
-
-```
-npm install express-metrics --save
-```
 
 ## Example
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "git://github.com/dgaubert/express-metrics.git"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha test/**/*.spec.js --require should --timeout=5000",
+    "test": "./node_modules/mocha/bin/mocha test/**/*.spec.js --require should --timeout=5000 --exit",
     "test:watch": "npm run test -- -w",
     "lint": "jshint *.js"
   },

--- a/package.json
+++ b/package.json
@@ -13,19 +13,19 @@
   "devDependencies": {
     "express": "^4.12.2",
     "jshint": "latest",
+    "mocha": "^5.2.0",
     "q": "^1.2.0",
     "request": "^2.53.0",
     "should": "^5.1.0",
-    "supertest": "^0.15.0",
     "sinon": "^1.15.3",
-    "mocha": "^2.2.1"
+    "supertest": "^3.3.0"
   },
   "repository": {
     "type": "git",
     "url": "git://github.com/dgaubert/express-metrics.git"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha test/**/*.spec.js --require should",
+    "test": "./node_modules/mocha/bin/mocha test/**/*.spec.js --require should --timeout=5000",
     "test:watch": "npm run test -- -w",
     "lint": "jshint *.js"
   },


### PR DESCRIPTION
Spinning up the cluster mode in the before statement of the unit tests
was taking longer than the default 2 seconds, therefore the timeout has
been increased to 5s.